### PR TITLE
Update ShaderProgram.java

### DIFF
--- a/02.Square/app/src/main/java/kr/pe/burt/android/square/glkit/ShaderProgram.java
+++ b/02.Square/app/src/main/java/kr/pe/burt/android/square/glkit/ShaderProgram.java
@@ -178,6 +178,7 @@ public class ShaderProgram {
         for(int i=0; i<numAttributes; i++) {
             params.compact();
             params.put(0, 1);
+            params.position(0);
             type.clear();
             String name = GLES20.glGetActiveAttrib(programHandle, i, params, type);
             int location = GLES20.glGetAttribLocation(programHandle, name);


### PR DESCRIPTION
저도 정확한 원인은 모르겠으나
제 기종인 A7에서 params를 출력했을땐 position이 1로 기본으로 설정이 되어 있어서 오류가 나서 position(0)을 추가해서 에러를 고쳤는데
다른 휴대폰에선 바꾸지 않아도 되는 기종도 있더라구요
그렇지만 경우를 생각해서 넣는게 좋을 것같습니다.